### PR TITLE
feat(ci): add keyless CI/CD deploy and open source governance

### DIFF
--- a/.claude/rules/eatp.md
+++ b/.claude/rules/eatp.md
@@ -1,0 +1,46 @@
+# EATP SDK Rules
+
+## Scope
+
+These rules apply when working with EATP SDK code (`**/eatp/**` files).
+
+## SDK Conventions
+
+### Dataclasses
+
+- Use `@dataclass` (NOT Pydantic) for all data types
+- Every `@dataclass` MUST have `to_dict()` → `Dict[str, Any]` and `@classmethod from_dict()` → Self
+- Enums serialize as `.value`, datetimes as `.isoformat()`
+
+### Module Structure
+
+- `from __future__ import annotations` in every module
+- `# Copyright 2026 Terrene Foundation` + `# SPDX-License-Identifier: Apache-2.0` header
+- `logger = logging.getLogger(__name__)` in every module
+- Explicit `__all__` in every module
+- `str`-backed `Enum` classes for JSON-friendly serialization
+
+### Error Handling
+
+- All errors MUST inherit from `TrustError` (in `eatp.exceptions`)
+- All errors MUST include `.details: Dict[str, Any]` parameter
+- Fail-closed: unknown/error states → deny, NEVER silently permit
+
+### Cryptography
+
+- Ed25519 is the mandatory signing algorithm
+- HMAC is optional overlay (HMAC alone is NEVER sufficient for external verification)
+- Constant-time comparison via `hmac.compare_digest()` — NEVER use `==` for signature comparison
+- AWS KMS uses ECDSA P-256 (Ed25519 not available in KMS) — document the algorithm mismatch
+
+### Trust Model
+
+- Monotonic escalation only: AUTO_APPROVED → FLAGGED → HELD → BLOCKED (never downgrade)
+- Bounded collections: `maxlen=10000`, trim oldest 10% at capacity
+- `None` role = all-access (backward-compatible, no RBAC enforcement)
+
+### Cross-SDK Alignment
+
+- Both Python and Rust SDKs implement the spec independently (D6)
+- Convention names may differ (Python snake_case vs Rust snake_case) but semantics MUST match
+- New spec-level concepts require Rust team coordination before implementation

--- a/.claude/rules/trust-plane-security.md
+++ b/.claude/rules/trust-plane-security.md
@@ -1,0 +1,200 @@
+# Trust-Plane Security Rules
+
+## Scope
+
+These rules apply when working with trust-plane and EATP store code:
+
+- `**/trustplane/**`
+- `**/eatp/store/**`
+
+These rules supplement `.claude/rules/security.md`. Both apply to trust-plane files.
+Violations during code review by intermediate-reviewer are BLOCK-level findings.
+
+## MUST Rules
+
+### 1. No Bare `open()` or `Path.read_text()` for Record Files
+
+```python
+# DO:
+from trustplane._locking import safe_read_json, safe_open
+data = safe_read_json(path)
+
+# DO NOT:
+with open(path) as f:           # Follows symlinks — attacker redirects to arbitrary file
+    data = json.load(f)
+data = json.loads(path.read_text())  # No symlink protection, no fd safety
+```
+
+**Why**: `safe_read_json()` and `safe_open()` use `O_NOFOLLOW` to prevent symlink attacks. Bare `open()` and `Path.read_text()` bypass all protections.
+
+### 2. `validate_id()` on Every Externally-Sourced Record ID
+
+```python
+# DO:
+from trustplane._locking import validate_id
+validate_id(record_id)  # Raises ValueError on "../", "/", null bytes, etc.
+path = store_dir / f"{record_id}.json"
+
+# DO NOT:
+path = store_dir / f"{user_input}.json"  # Path traversal: "../../../etc/passwd"
+cursor.execute(f"SELECT * FROM records WHERE id = '{record_id}'")  # SQL injection
+```
+
+**Why**: The regex `^[a-zA-Z0-9_-]+$` prevents directory traversal and SQL injection via IDs. Every method that accepts a record ID or query parameter MUST validate before use.
+
+### 3. `math.isfinite()` on All Numeric Constraint Fields
+
+```python
+# DO (in __post_init__ or from_dict):
+if self.max_cost is not None and not math.isfinite(self.max_cost):
+    raise ValueError("max_cost must be finite")
+
+# DO NOT:
+if self.max_cost is not None and self.max_cost < 0:
+    raise ValueError("negative")  # NaN passes, Inf passes
+```
+
+**Why**: `NaN` and `Inf` bypass numeric comparisons (`NaN < 0` is `False`, `Inf < 0` is `False`). Constraints set to `NaN` make all checks pass silently.
+
+### 4. Bounded Collections (`maxlen=10000`)
+
+```python
+# DO:
+call_log: deque = field(default_factory=lambda: deque(maxlen=10000))
+
+# DO NOT:
+call_log: list = field(default_factory=list)  # Grows without bound -> OOM
+```
+
+**Why**: Unbounded collections in long-running processes lead to memory exhaustion. Trim oldest 10% when at capacity.
+
+### 5. Parameterized SQL for All Database Queries
+
+```python
+# DO:
+cursor.execute("SELECT * FROM decisions WHERE id = ?", (record_id,))
+cursor.execute("INSERT INTO decisions (id, data) VALUES (?, ?)", (id, data))
+
+# DO NOT:
+cursor.execute(f"SELECT * FROM decisions WHERE id = '{record_id}'")
+cursor.execute("INSERT INTO decisions VALUES (" + id + ", " + data + ")")
+```
+
+**Why**: f-string interpolation into SQL enables injection. Even validated IDs should use parameterized queries as defense-in-depth.
+
+### 6. SQLite Database File Permissions
+
+```python
+# DO (on POSIX):
+import os, stat
+db_path.touch(mode=0o600)  # Owner read/write only
+os.chmod(db_path, stat.S_IRUSR | stat.S_IWUSR)
+
+# DO NOT:
+db_path.touch()  # Default permissions may be world-readable
+```
+
+**Why**: SQLite database files (`.db`, `-wal`, `-shm`) contain all trust records. Default permissions may expose them to other users on shared systems.
+
+### 7. All Record Writes Through `atomic_write()`
+
+```python
+# DO:
+from trustplane._locking import atomic_write
+atomic_write(path, json.dumps(record.to_dict()))
+
+# DO NOT:
+with open(path, 'w') as f:  # Partial write on crash = corrupted record
+    json.dump(record, f)
+```
+
+**Why**: `atomic_write()` uses temp file + `fsync` + `os.replace()` for crash safety. The `O_NOFOLLOW` flag also prevents symlink attacks during writes.
+
+## MUST NOT Rules
+
+### 1. MUST NOT Use `==` to Compare HMAC Digests
+
+```python
+# DO:
+import hmac as hmac_mod
+if not hmac_mod.compare_digest(stored_hash, computed_hash):
+    raise TamperDetectedError(...)
+
+# DO NOT:
+if stored_hash != computed_hash:  # Timing side-channel for byte-by-byte forgery
+    raise TamperDetectedError(...)
+```
+
+**Why**: String equality (`==`) leaks timing information. An attacker can measure comparison time to determine how many bytes match.
+
+### 2. MUST NOT Downgrade Trust State
+
+```python
+# CORRECT: Monotonic escalation only
+# AUTO_APPROVED -> FLAGGED -> HELD -> BLOCKED (only forward)
+
+# FORBIDDEN:
+if some_condition:
+    verdict = Verdict.AUTO_APPROVED  # Downgrading from HELD is forbidden
+```
+
+**Why**: Trust state can only escalate, never relax. A HELD action cannot become AUTO_APPROVED — it must be explicitly resolved through the hold workflow.
+
+### 3. MUST NOT Write Records Without `atomic_write()`
+
+Any filesystem record write that bypasses `atomic_write()` is a security defect. See MUST Rule 7.
+
+### 4. MUST NOT Leave Private Key Material in Memory
+
+```python
+# DO:
+key_mgr.register_key(key_id, private_key)
+del private_key  # Remove reference immediately
+
+# On revocation:
+self._keys[key_id] = ""  # Clear material, keep tombstone
+
+# DO NOT:
+key_mgr.register_key(key_id, private_key)
+# private_key persists in scope — visible to memory dumps
+```
+
+**Why**: Private key material in memory is vulnerable to debugger inspection and memory dumps.
+
+### 5. MUST NOT Construct `MultiSigPolicy` as Mutable
+
+```python
+# DO:
+@dataclass(frozen=True)
+class MultiSigPolicy:
+    required_signatures: int
+    ...
+
+# DO NOT:
+@dataclass  # Mutable — fields can be changed after __post_init__ validation
+class MultiSigPolicy:
+    ...
+```
+
+**Why**: Without `frozen=True`, an attacker with object reference can bypass `__post_init__` validation by directly setting fields.
+
+### 8. MUST: Use `normalize_resource_path()` for All Constraint Pattern Storage and Comparison
+
+All constraint patterns and resource paths MUST be normalized via `normalize_resource_path()` before storage or comparison. Direct use of `posixpath.normpath`, `os.path.normpath`, or `Path.as_posix()` for constraint patterns is FORBIDDEN.
+
+```python
+# DO:
+from trustplane.pathutils import normalize_resource_path
+norm = normalize_resource_path(user_path)
+
+# DO NOT:
+norm = os.path.normpath(user_path)  # Platform-dependent, Windows produces backslashes
+norm = Path(user_path).as_posix()   # Doesn't collapse double slashes
+```
+
+**Why**: `os.path.normpath` produces backslashes on Windows, breaking cross-platform constraint matching. `Path.as_posix()` doesn't collapse double slashes. `normalize_resource_path()` provides consistent forward-slash normalization on all platforms.
+
+## Cross-References
+
+- `.claude/rules/security.md` — Global security rules (secrets, injection, input validation)
+- `.claude/rules/eatp.md` — EATP SDK conventions (dataclasses, error hierarchy, cryptography)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/validate-bash-command.js\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/validate-prod-deploy.js\"",
+            "timeout": 10
           }
         ]
       }
@@ -25,6 +30,11 @@
             "type": "command",
             "command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/validate-workflow.js\"",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/validate-deployment.js\"",
+            "timeout": 10
           },
           {
             "type": "command",

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,27 @@
+# CARE Platform — Code Owners
+# These owners are automatically requested for review on PRs.
+
+# Default owner for everything
+* @esperie
+
+# Backend (Python)
+/src/care_platform/ @esperie
+/tests/ @esperie
+
+# Web frontend
+/apps/web/ @esperie
+
+# Flutter mobile
+/apps/mobile/ @esperie
+
+# CI/CD and infrastructure
+/.github/ @esperie
+/Dockerfile @esperie
+/docker-compose.yml @esperie
+/deploy/ @esperie
+
+# COC setup (agents, rules, skills)
+/.claude/ @esperie
+
+# Documentation
+/docs/ @esperie

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug Report
+description: Report a bug in the CARE Platform
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill in the details below.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened?
+      placeholder: A clear description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: How can we reproduce this?
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should have happened?
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Backend (Python API)
+        - Web Dashboard (Next.js)
+        - Flutter App
+        - CLI
+        - Docker/Deployment
+        - Documentation
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      placeholder: v0.1.0

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature Request
+description: Suggest a feature for the CARE Platform
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature! Please describe what you'd like.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should this work?
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Backend (Python API)
+        - Web Dashboard (Next.js)
+        - Flutter App
+        - CLI / Org Builder
+        - Trust Layer / EATP
+        - DM Team Vertical
+        - Documentation
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "ci"
+
+  # npm (web dashboard)
+  - package-ecosystem: "npm"
+    directory: "/apps/web"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "frontend"
+    open-pull-requests-limit: 5

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- 1-3 bullet points describing what this PR does -->
+
+## Type
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactoring
+- [ ] Documentation
+- [ ] CI/CD
+- [ ] Dependencies
+
+## Test Plan
+
+- [ ] Unit tests pass (`pytest tests/unit/`)
+- [ ] Integration tests pass (`pytest tests/integration/`)
+- [ ] Lint passes (`ruff check src/ tests/`)
+- [ ] Flutter analyze passes (if mobile changes)
+- [ ] Manual testing completed
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] No secrets or credentials committed
+- [ ] Documentation updated (if applicable)
+- [ ] No breaking changes (or migration path documented)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,140 @@
+# Copyright 2026 Terrene Foundation
+# Licensed under the Apache License, Version 2.0
+
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      deploy_api:
+        description: "Deploy API"
+        type: boolean
+        default: true
+      deploy_web:
+        description: "Deploy Web Dashboard"
+        type: boolean
+        default: true
+
+# Only allow one deploy at a time
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write # Required for Workload Identity Federation
+
+env:
+  PROJECT_ID: terrene-care
+  REGION: asia-southeast1
+  REGISTRY: asia-southeast1-docker.pkg.dev/terrene-care/care-platform
+  WIF_PROVIDER: projects/129371016531/locations/global/workloadIdentityPools/github-actions/providers/github-oidc
+  SA_EMAIL: github-actions-deploy@terrene-care.iam.gserviceaccount.com
+
+jobs:
+  # Run tests before deploying
+  test:
+    name: Pre-deploy Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint
+        run: ruff check src/care_platform/ tests/
+
+      - name: Unit tests
+        run: pytest tests/unit/ --cov=src/care_platform --cov-fail-under=80 -q
+
+  # Deploy API to Cloud Run
+  deploy-api:
+    name: Deploy API
+    needs: [test]
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_api == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Keyless auth via Workload Identity Federation
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.SA_EMAIL }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and push API image
+        run: |
+          IMAGE=${{ env.REGISTRY }}/api:${{ github.sha }}
+          docker build -t $IMAGE -t ${{ env.REGISTRY }}/api:latest .
+          docker push $IMAGE
+          docker push ${{ env.REGISTRY }}/api:latest
+
+      - name: Deploy API to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: care-platform-api
+          region: ${{ env.REGION }}
+          image: ${{ env.REGISTRY }}/api:${{ github.sha }}
+
+      - name: Verify API health
+        run: |
+          URL=$(gcloud run services describe care-platform-api --region=${{ env.REGION }} --format='value(status.url)')
+          curl -sf "$URL/health" | python -m json.tool
+
+  # Deploy Web Dashboard to Cloud Run
+  deploy-web:
+    name: Deploy Web Dashboard
+    needs: [test]
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_web == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.SA_EMAIL }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Build and push Web image
+        working-directory: apps/web
+        run: |
+          IMAGE=${{ env.REGISTRY }}/web:${{ github.sha }}
+          docker build -t $IMAGE -t ${{ env.REGISTRY }}/web:latest .
+          docker push $IMAGE
+          docker push ${{ env.REGISTRY }}/web:latest
+
+      - name: Deploy Web to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: care-platform-web
+          region: ${{ env.REGION }}
+          image: ${{ env.REGISTRY }}/web:${{ github.sha }}
+
+      - name: Verify Web health
+        run: |
+          URL=$(gcloud run services describe care-platform-web --region=${{ env.REGION }} --format='value(status.url)')
+          curl -sf "$URL" -o /dev/null -w "Web dashboard: HTTP %{http_code}\n"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,8 @@ Every implementation decision must align with the CARE, EATP, and CO specificati
 | 3-tier testing strategy           | `rules/testing.md`           | `tests/**`, `**/*test*`, `**/*spec*`, `conftest.py` |
 | Terrene naming & terminology      | `rules/terrene-naming.md`    | Global                                              |
 | Documentation & version accuracy  | `rules/documentation.md`     | `README.md`, `docs/**`, `CHANGELOG.md`              |
-| Constitution consistency          | `rules/constitution.md`      | Scoped                                              |
+| EATP implementation rules         | `rules/eatp.md`              | `**/*.py`, EATP integration code                    |
+| Trust Plane security patterns     | `rules/trust-plane-security.md` | Global — trust/security code                     |
 | Auto-generated workflow instincts | `rules/learned-instincts.md` | Global                                              |
 
 ## Agents
@@ -139,7 +140,6 @@ Every implementation decision must align with the CARE, EATP, and CO specificati
 - **eatp-expert** — EATP trust protocol (trust lineage, verification gradient)
 - **co-expert** — CO methodology (7 principles, 5 layers)
 - **coc-expert** — COC: CO applied to Codegen (5-layer architecture, anti-amnesia)
-- **constitution-expert** — Terrene Foundation constitution (77 clauses, 11 EPs, phased governance)
 
 ### Strategy
 
@@ -188,7 +188,6 @@ For Kailash SDK implementation patterns, see `.claude/skills/` — organized by 
 - **27-care-reference** — CARE framework reference (Dual Plane, Mirror Thesis, governance)
 - **28-coc-reference** — COC framework reference (5-layer architecture, anti-amnesia)
 - **co-reference** — CO methodology reference (7 principles, 5 layers, domain applications)
-- **29-constitution-reference** — Constitution reference (77 clauses, 11 EPs, phased governance)
 
 ### Project Skills
 

--- a/scripts/hooks/validate-prod-deploy.js
+++ b/scripts/hooks/validate-prod-deploy.js
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+/**
+ * Hook: validate-prod-deploy
+ * Event: PreToolUse
+ * Matcher: Bash
+ * Purpose: Block direct production deployment commands unless staging has passed.
+ *
+ * Intercepts Bash commands that touch production Docker containers and
+ * requires .staging-passed to exist with the current git HEAD commit.
+ *
+ * To use this hook, register it in .claude/settings.json under PreToolUse:Bash.
+ * See deploy/scripts/ for the stage.sh and deploy.sh that write/read the marker.
+ *
+ * Exit Codes:
+ *   0 = allow (command is safe or staging verified)
+ *   2 = block (direct production deploy without staging)
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const TIMEOUT_MS = 5000;
+const timeout = setTimeout(() => {
+  // Timeout = allow (fail-open to avoid blocking all Bash commands)
+  process.exit(0);
+}, TIMEOUT_MS);
+
+async function main() {
+  try {
+    const input = JSON.parse(fs.readFileSync("/dev/stdin", "utf8"));
+    const toolName = input.tool_name;
+    const toolInput = input.tool_input || {};
+    const command = toolInput.command || "";
+
+    // Only check Bash commands
+    if (toolName !== "Bash") {
+      clearTimeout(timeout);
+      process.exit(0);
+      return;
+    }
+
+    // Patterns that indicate production deployment
+    // Projects should add their own container name patterns below.
+    const PROD_PATTERNS = [
+      // Generic docker compose prod file patterns
+      /docker.*compose.*prod.*up/i,
+      /docker.*compose.*prod.*build/i,
+      /docker.*compose.*prod.*restart/i,
+      /docker.*compose.*-f.*docker-compose\.prod/i,
+      // bare docker restart (single container restarts bypass compose)
+      /docker\s+restart\s+\S+/,
+      // SSH to production server running docker compose
+      /ssh\s+.*docker\s+(compose|stack)/i,
+    ];
+
+    // Patterns that are always allowed (read-only, logs, status, dev scripts)
+    const SAFE_PATTERNS = [
+      /docker.*logs/i,
+      /docker.*ps/i,
+      /docker.*inspect/i,
+      /docker.*images/i,
+      /docker\s+exec/i,
+      /git\s+(pull|log|status|diff)/i,
+      /curl/i,
+      /cat|grep|head|tail|ls/,
+      /deploy\/scripts\/stage\.sh/,
+      /deploy\/scripts\/promote\.sh/,
+      /deploy\/scripts\/dev\.sh/,
+      /docker.*compose.*dev.*up/i,
+      /docker.*compose.*staging.*up/i,
+    ];
+
+    // Check safe patterns first — if command is clearly safe, allow immediately
+    for (const safe of SAFE_PATTERNS) {
+      if (safe.test(command)) {
+        clearTimeout(timeout);
+        process.exit(0);
+        return;
+      }
+    }
+
+    // Check if command matches a production deploy pattern
+    let isProductionDeploy = false;
+    for (const pattern of PROD_PATTERNS) {
+      if (pattern.test(command)) {
+        isProductionDeploy = true;
+        break;
+      }
+    }
+
+    if (!isProductionDeploy) {
+      clearTimeout(timeout);
+      process.exit(0);
+      return;
+    }
+
+    // Skip-staging escape hatch — allow but warn loudly
+    if (command.includes("--skip-staging")) {
+      console.error(
+        "\n" +
+        "[DEPLOY HOOK] WARNING: --skip-staging detected.\n" +
+        "[DEPLOY HOOK] Allowing direct production deploy WITHOUT staging verification.\n" +
+        "[DEPLOY HOOK] You MUST document the reason in deploy/deployment-config.md.\n"
+      );
+      clearTimeout(timeout);
+      process.exit(0);
+      return;
+    }
+
+    // Locate repo root by walking up from cwd or script location
+    let repoRoot;
+    try {
+      repoRoot = execSync("git rev-parse --show-toplevel", {
+        encoding: "utf8",
+        timeout: 3000,
+      }).trim();
+    } catch {
+      // Not in a git repo or git unavailable — fail open
+      clearTimeout(timeout);
+      process.exit(0);
+      return;
+    }
+
+    const markerPath = path.join(repoRoot, ".staging-passed");
+
+    // Check that .staging-passed exists
+    if (!fs.existsSync(markerPath)) {
+      console.error(
+        "\n" +
+        "╔══════════════════════════════════════════════════════════╗\n" +
+        "║  BLOCKED: Production deploy without staging             ║\n" +
+        "║                                                          ║\n" +
+        "║  Run staging first:                                      ║\n" +
+        "║    bash deploy/scripts/promote.sh                        ║\n" +
+        "║                                                          ║\n" +
+        "║  Or step-by-step on the server:                          ║\n" +
+        "║    bash deploy/scripts/stage.sh                          ║\n" +
+        "║    bash deploy/scripts/deploy.sh                         ║\n" +
+        "║                                                          ║\n" +
+        "║  Emergency bypass (document the reason afterward):       ║\n" +
+        "║    Add --skip-staging to your command                    ║\n" +
+        "╚══════════════════════════════════════════════════════════╝\n"
+      );
+      clearTimeout(timeout);
+      process.exit(2); // Block
+      return;
+    }
+
+    // Verify that .staging-passed contains the current commit
+    const marker = fs.readFileSync(markerPath, "utf8").trim();
+    let currentCommit;
+    try {
+      currentCommit = execSync("git rev-parse HEAD", {
+        cwd: repoRoot,
+        encoding: "utf8",
+        timeout: 3000,
+      }).trim();
+    } catch {
+      // Can't determine current commit — fail open rather than block legitimate work
+      clearTimeout(timeout);
+      process.exit(0);
+      return;
+    }
+
+    const shortHash = currentCommit.substring(0, 7);
+    if (!marker.includes(shortHash)) {
+      console.error(
+        "\n" +
+        "╔══════════════════════════════════════════════════════════╗\n" +
+        "║  BLOCKED: Staging marker is stale                        ║\n" +
+        "║                                                          ║\n" +
+        "║  Code has changed since staging last passed.             ║\n" +
+        `║  Current commit: ${shortHash.padEnd(42)}║\n` +
+        `║  Staging marker: ${marker.substring(0, 7).padEnd(42)}║\n` +
+        "║                                                          ║\n" +
+        "║  Re-run staging:                                         ║\n" +
+        "║    bash deploy/scripts/promote.sh                        ║\n" +
+        "╚══════════════════════════════════════════════════════════╝\n"
+      );
+      clearTimeout(timeout);
+      process.exit(2); // Block
+      return;
+    }
+
+    // Staging verified and current — allow production deploy
+    console.error(
+      `[DEPLOY HOOK] Staging verified (${shortHash}). Allowing production deploy.`
+    );
+    clearTimeout(timeout);
+    process.exit(0);
+  } catch (err) {
+    // Parse error or unexpected failure — fail open to avoid blocking legitimate work
+    clearTimeout(timeout);
+    process.exit(0);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary

- Keyless CI/CD deploys from GitHub Actions to GCP Cloud Run via Workload Identity Federation (zero credentials stored)
- Open source governance: CODEOWNERS, issue/PR templates, Dependabot
- Sync COC rules from kailash-coc-claude-py template (eatp.md, trust-plane-security.md)
- Remove constitution artifacts (belong in terrene knowledge base, not the platform repo)

## What's configured

**Workload Identity Federation (keyless deploy):**
- WIF Pool: `github-actions` (trusts `terrene-foundation` org only)
- WIF Provider: GitHub OIDC with repo owner attribute condition
- Service Account: `github-actions-deploy@terrene-care.iam.gserviceaccount.com`
- Roles: Cloud Run Admin, Artifact Registry Writer, Cloud Build Editor

**Deploy workflow (`deploy.yml`):**
- Triggers on push to main or manual dispatch
- Runs tests first, then builds and deploys API + Web to Cloud Run
- Health check after deploy
- Concurrency control (one deploy at a time)

**Open source governance:**
- CODEOWNERS → auto-request reviews
- Bug report + feature request issue templates
- PR template with checklist
- Dependabot for Python, npm, and Actions dependency updates

## Test plan

- [ ] CI passes (lint, tests)
- [ ] Deploy workflow syntax validates
- [ ] Branch protection rules verified via `gh api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)