### PR TITLE
chore(deps): upgrade kailash 2.2.0, kailash-nexus 1.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     # Kailash SDK ecosystem (aligned with kailash-coc-claude-py template)
-    "kailash[trust,pact]>=2.1.0",
+    "kailash[trust,pact]>=2.2.0",
     "kailash-pact>=0.4.0",
     "kailash-dataflow>=1.2.0",
     "kailash-kaizen>=2.3.0",
@@ -53,7 +53,7 @@ dependencies = [
 [project.optional-dependencies]
 # Nexus multi-channel deployment
 nexus = [
-    "kailash-nexus>=1.4.3",
+    "kailash-nexus>=1.5.0",
 ]
 # kaizen-agents (GovernedSupervisor — Delegate engine)
 agents = [
@@ -109,6 +109,9 @@ asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
 filterwarnings = [
     "ignore::DeprecationWarning",
+]
+markers = [
+    "regression: permanent regression tests that guard against previously-fixed bugs",
 ]
 
 [tool.black]

--- a/tests/unit/persistence/test_cost_tracking.py
+++ b/tests/unit/persistence/test_cost_tracking.py
@@ -147,10 +147,12 @@ class TestMonthlySpend:
     def test_monthly_spend_excludes_other_months(self):
         tracker = CostTracker()
         now = datetime.now(UTC)
+        # Use day=1 to avoid day-out-of-range when previous month has fewer days
+        first_of_month = now.replace(day=1)
         last_month = (
-            now.replace(month=now.month - 1)
-            if now.month > 1
-            else now.replace(year=now.year - 1, month=12)
+            first_of_month.replace(month=first_of_month.month - 1)
+            if first_of_month.month > 1
+            else first_of_month.replace(year=first_of_month.year - 1, month=12)
         )
         tracker.record(_make_record(team_id="team-ops", cost_usd="1.00", timestamp=now))
         tracker.record(_make_record(team_id="team-ops", cost_usd="9.00", timestamp=last_month))


### PR DESCRIPTION
## Summary

- Upgrade kailash >=2.1.0 → >=2.2.0 (major upgrade)
- Upgrade kailash-nexus >=1.4.3 → >=1.5.0
- Fix pre-existing date bug in cost tracking test (day-out-of-range on months with 29-31 days)

## Test plan

- [x] `pytest` — 1900 passed, 44 skipped, 0 failures (8.55s)
- [x] No breaking changes from kailash 2.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)