### PR TITLE
chore(coc): sync COC artifacts v1.0.0

### DIFF
--- a/.claude/.coc-sync-marker
+++ b/.claude/.coc-sync-marker
@@ -1,1 +1,1 @@
-2026-03-30T00:00:00Z
+{"synced_at": "2026-03-29T20:19:44Z", "source": "kailash-coc-claude-py", "target": "pact", "source_version": "1.0.0", "updated": 2, "added": 0}

--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,0 +1,12 @@
+{
+  "version": "1.0.0",
+  "type": "coc-project",
+  "variant": "py",
+  "updated": "2026-03-29",
+  "description": "pact project",
+  "upstream": {
+    "template": "kailash-coc-claude-py",
+    "template_version": "1.0.0",
+    "synced_at": "2026-03-29T20:19:44Z"
+  }
+}

--- a/.claude/commands/codify.md
+++ b/.claude/commands/codify.md
@@ -73,12 +73,15 @@ After artifacts are updated and validated locally, create a proposal for upstrea
 **DO NOT sync directly to COC template repos.** All distribution flows through kailash/ via `/sync`.
 
 1. Create `.claude/.proposals/` directory if it doesn't exist
-2. Generate `.claude/.proposals/latest.yaml` listing all artifact changes:
+2. Read the SDK version from `pyproject.toml` (py) or `Cargo.toml` (rs) and the COC artifact version from `.claude/VERSION`
+3. Generate `.claude/.proposals/latest.yaml` listing all artifact changes:
 
 ```yaml
 source_repo: kailash-py # or kailash-rs
 codify_date: YYYY-MM-DD
 codify_session: "type(scope): description of work"
+sdk_version: "2.2.1"  # from pyproject.toml or Cargo.toml
+coc_version: "1.0.0"  # from .claude/VERSION
 
 changes:
   - file: relative/path/to/artifact.md

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -44,11 +44,29 @@ Search paths (in order):
 2. `../../kailash/{template}/` (kailash parent)
 3. Ask user for path
 
-### 3. Compare freshness
+### 3. Check SDK version compatibility
+
+Read this project's SDK version from `pyproject.toml` (look for `kailash` or `kailash-enterprise` in `[project.dependencies]` or `[tool.poetry.dependencies]`). Read the template's VERSION file for the `build_version` (the kailash/ source version the template was synced from).
+
+Report both in the sync header:
+```
+Project SDK: kailash==2.0.0 (from pyproject.toml)
+Template COC: 1.0.0 (from template .claude/VERSION)
+```
+
+If the template artifacts were codified from a newer SDK version than the project uses, warn:
+```
+⚠ Template artifacts may reference SDK features newer than your installed version.
+  Consider upgrading: pip install --upgrade kailash
+```
+
+This is informational — sync proceeds regardless. The warning helps developers understand why some skill content may reference unfamiliar APIs.
+
+### 4. Compare freshness
 
 Compare `.coc-sync-marker` timestamps. If already fresh: "Already up to date."
 
-### 4. Pull and merge
+### 5. Pull and merge
 
 **Updated from template** (shared artifacts):
 
@@ -79,17 +97,17 @@ Compare `.coc-sync-marker` timestamps. If already fresh: "Already up to date."
 - `scripts/hooks/*.js` — updated
 - `scripts/hooks/lib/*.js` — updated
 
-### 5. Verify integrity
+### 6. Verify integrity
 
 - Every hook in `settings.json` has a corresponding script
 - Every `require("./lib/...")` has a matching lib file
 
-### 6. Update tracking
+### 7. Update tracking
 
 - Write `.claude/.coc-sync-marker` with timestamp and template source
 - If `.claude/VERSION` exists, update `upstream.version` to match the template's VERSION version (so future session-start checks report correctly)
 
-### 7. Report
+### 8. Report
 
 ```
 ## Sync Complete: kailash-coc-claude-py → this repo


### PR DESCRIPTION
## Summary
- Sync COC artifacts from kailash-coc-claude-py v1.0.0 template
- Updated agents, commands, rules, skills, guides, hooks
- Added SDK version awareness to /sync and /codify commands
- Added VERSION file for COC artifact currency tracking

## Test plan
- [ ] COC hooks operational (session-start, validate-workflow)
- [ ] /sync command available and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)