### PR TITLE
chore(coc): sync COC artifacts to v1.4.0

### DIFF
--- a/.claude/.coc-sync-marker
+++ b/.claude/.coc-sync-marker
@@ -1,1 +1,1 @@
-{"synced_at": "2026-04-01T05:43:06Z", "source": "kailash-coc-claude-py", "target": "pact", "source_version": "1.2.0", "updated": 9, "added": 1, "preserved": 2}
+{"synced_at": "2026-04-01T19:15:00Z", "source": "kailash-coc-claude-py", "target": "pact", "source_version": "1.4.0", "updated": 2, "added": 0, "preserved": 2}

--- a/.claude/VERSION
+++ b/.claude/VERSION
@@ -1,16 +1,44 @@
 {
-  "version": "1.2.0",
+  "version": "1.4.0",
   "type": "coc-use-template",
   "description": "COC USE template for Python SDK projects",
-  "released": "2026-03-30",
+  "released": "2026-04-01",
   "upstream": {
     "name": "kailash",
     "type": "coc-source",
-    "version": "1.0.0",
-    "build_version": "2.2.1",
-    "synced_at": "2026-03-30T12:00:00Z"
+    "version": "1.1.0",
+    "build_version": "2.4.0",
+    "synced_at": "2026-04-01T18:00:00Z"
   },
   "changelog": [
+    {
+      "version": "1.4.0",
+      "date": "2026-04-01",
+      "summary": "Downstream proposal guard + SDK pin update to 2.4.0",
+      "changes": [
+        "UPDATED: commands/codify.md — Step 7 scoped to BUILD repos only; downstream repos skip proposals",
+        "UPDATED: rules/artifact-flow.md — New Rule 2a: downstream repos do not propose upstream"
+      ]
+    },
+    {
+      "version": "1.3.0",
+      "date": "2026-04-01",
+      "summary": "Dependency install normalization + Python venv enforcement rule",
+      "changes": [
+        "NEW: rules/python-environment.md — Python venv isolation policy (uv + .venv enforcement)"
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "date": "2026-03-31",
+      "summary": "Gate 1 py changes: DataFlow SyncExpress, PACT approve_bridge, __del__ patterns, Nexus K8s probes, Kaizen agent reference",
+      "changes": [
+        "UPDATED: skills/02-dataflow/dataflow-express.md — SyncExpress API, SQLite timestamp fix",
+        "UPDATED: skills/29-pact/pact-governance-engine.md — approve_bridge pattern",
+        "UPDATED: rules/patterns.md — __del__ cleanup patterns",
+        "UPDATED: skills/03-nexus/nexus-k8s-probes.md — K8s health probe patterns"
+      ]
+    },
     {
       "version": "1.1.0",
       "date": "2026-03-30",

--- a/.claude/commands/codify.md
+++ b/.claude/commands/codify.md
@@ -66,9 +66,19 @@ Ensure user-facing documentation reflects new capabilities. Verify README.md, do
 
 Validate that generated agents and skills are correct, complete, and secure. **claude-code-architect** verifies cc-artifacts compliance (descriptions under 120 chars, agents under 400 lines, commands under 150 lines, rules path-scoped, SKILL.md progressive disclosure).
 
-### 7. Create upstream proposal (MANDATORY)
+### 7. Create upstream proposal (BUILD repos only)
 
-After artifacts are updated and validated locally, create a proposal for upstream review at loom/ (the source of truth). This step is NOT optional — codification is incomplete without upstream propagation.
+**This step applies ONLY to BUILD repos** (kailash-py, kailash-rs). Detect by checking:
+
+- Git remote contains `kailash-py` or `kailash-rs`, OR
+- `pyproject.toml` contains `name = "kailash"` or `Cargo.toml` contains `name = "kailash"`
+
+**If this is a downstream project repo** (anything else): SKIP this step. Downstream repos consume COC artifacts from templates — they do not propose changes upstream. Artifact changes from `/codify` in downstream repos stay local to that project. Report:
+
+> Artifacts updated locally. This is a downstream project repo — changes stay local.
+> Only BUILD repos (kailash-py, kailash-rs) create upstream proposals.
+
+**If this is a BUILD repo**: Create a proposal for upstream review at loom/ (source of truth).
 
 **DO NOT sync directly to COC template repos.** All distribution flows through loom/ via `/sync`.
 
@@ -93,13 +103,13 @@ changes:
 status: pending_review
 ```
 
-3. For each changed artifact, suggest a tier:
+4. For each changed artifact, suggest a tier:
    - **cc**: Claude Code universal (guides, cc-audit)
    - **co**: Methodology universal (CO principles, journal, communication)
    - **coc**: Codegen, language-agnostic (workflow phases, analysis patterns)
    - **coc-py** / **coc-rs**: Language-specific (code examples, SDK patterns)
 
-4. Report to the developer:
+5. Report to the developer:
 
 > Artifacts updated locally and available in this repo. Proposal created at
 > `.claude/.proposals/latest.yaml` with {N} changes for upstream review.
@@ -129,9 +139,10 @@ Deploy these agents as a team for codification:
 - **testing-specialist** — Verify any code examples in skills are testable
 - **security-reviewer** — Audit agents/skills for prompt injection, insecure patterns, secrets exposure
 
-**Upstream proposal (step 7 — mandatory):**
+**Upstream proposal (step 7 — BUILD repos only):**
 
-- Generate `.claude/.proposals/latest.yaml` with tier suggestions for each changed artifact
+- Only in BUILD repos (kailash-py, kailash-rs): generate `.claude/.proposals/latest.yaml` with tier suggestions
+- Downstream project repos: skip proposal creation, changes stay local
 - See `rules/artifact-flow.md` for the controlled flow: BUILD repo → loom/ → templates
 
 ### Journal

--- a/.claude/rules/artifact-flow.md
+++ b/.claude/rules/artifact-flow.md
@@ -49,6 +49,20 @@ When `/codify` creates or modifies artifacts in a BUILD repo (kailash-py, kailas
 
 **Why**: Direct BUILD-to-template sync bypasses classification (global vs variant) and cross-SDK alignment.
 
+### 2a. Downstream Repos Do NOT Propose Upstream
+
+Downstream project repos (everything except kailash-py, kailash-rs) consume COC artifacts from USE templates. When `/codify` runs in a downstream repo, artifact changes stay **local to that project** — no proposal manifest is created.
+
+```
+# Downstream repo /codify:
+/codify → writes to project/.claude/ (local only, no proposal)
+
+# NOT this:
+/codify → creates .proposals/latest.yaml (wrong — no upstream path exists)
+```
+
+**Why**: Downstream repos have no authority over COC artifacts. Their `.claude/` is template-managed. Project-specific artifacts (local rules, learned instincts) are project knowledge, not COC-level insights.
+
 ### 3. /sync Is the Only Outbound Path
 
 Only `/sync` executed at `loom/` may write to COC template repos. No other command, agent, or manual process may modify template repo artifacts.


### PR DESCRIPTION
## Summary

- Syncs COC artifacts from upstream template `kailash-coc-claude-py` v1.2.0 → v1.4.0
- `codify.md` now scopes upstream proposals to BUILD repos only — downstream repos skip proposal creation
- `artifact-flow.md` adds Rule 2a: downstream repos do not propose upstream
- VERSION updated to 1.4.0 (build_version 2.4.0)

## Test plan

- [x] `/sync` confirmed all shared artifacts match template
- [x] No code changes — artifact metadata and documentation only
- [x] No regressions possible (no Python/TS changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)